### PR TITLE
fix: 会话摘要触发改用累计消息计数，与滑动窗口解耦

### DIFF
--- a/src/main/java/com/aiagent/infrastructure/memory/LongContextManager.java
+++ b/src/main/java/com/aiagent/infrastructure/memory/LongContextManager.java
@@ -28,6 +28,7 @@ public class LongContextManager {
 
     private static final String HISTORY_PREFIX = "ai:history:";
     private static final String SUMMARY_PREFIX = "ai:summary:";
+    private static final String TURN_COUNT_PREFIX = "ai:turns:";
     private static final int DEFAULT_SUMMARY_INTERVAL = 5;
     private static final int DEFAULT_SLIDING_WINDOW_SIZE = 10;
     private static final int SUMMARY_RETRIEVE_TOP_K = 3;
@@ -84,11 +85,16 @@ public class LongContextManager {
 
         redisTemplate.opsForValue().set(historyKey, messages, aiProperties.getSession().getTtl(), TimeUnit.SECONDS);
 
+        // Counted separately from the history list, whose size is capped by the sliding window.
+        String turnCountKey = TURN_COUNT_PREFIX + sessionId;
+        Long totalTurns = redisTemplate.opsForValue().increment(turnCountKey);
+        redisTemplate.expire(turnCountKey, aiProperties.getSession().getTtl(), TimeUnit.SECONDS);
+
         int summaryInterval = aiProperties.getSession().getSummaryInterval() > 0
                 ? aiProperties.getSession().getSummaryInterval()
                 : DEFAULT_SUMMARY_INTERVAL;
-        if (messages.size() % summaryInterval == 0 && messages.size() >= summaryInterval) {
-            generateAndStoreSummary(sessionId, messages, summaryInterval);
+        if (totalTurns != null && totalTurns % summaryInterval == 0 && totalTurns >= summaryInterval) {
+            generateAndStoreSummary(sessionId, messages, summaryInterval, totalTurns);
         }
     }
 
@@ -112,7 +118,7 @@ public class LongContextManager {
     }
 
     @SuppressWarnings("unchecked")
-    private void generateAndStoreSummary(String sessionId, List<Map<String, String>> messages, int summaryInterval) {
+    private void generateAndStoreSummary(String sessionId, List<Map<String, String>> messages, int summaryInterval, long totalTurns) {
         try {
             int start = Math.max(0, messages.size() - summaryInterval);
             List<Map<String, String>> recentMessages = messages.subList(start, messages.size());
@@ -133,7 +139,7 @@ public class LongContextManager {
             Map<String, Object> summaryEntry = new HashMap<>();
             summaryEntry.put("summary", summary);
             summaryEntry.put("timestamp", System.currentTimeMillis());
-            summaryEntry.put("round", messages.size());
+            summaryEntry.put("round", totalTurns);
 
             float[] embedding = embedText(summary);
             if (embedding != null) {
@@ -146,7 +152,7 @@ public class LongContextManager {
             }
 
             redisTemplate.opsForValue().set(summaryKey, summaries, aiProperties.getSession().getTtl(), TimeUnit.SECONDS);
-            log.info("Generated session summary: sessionId={}, round={}, length={}", sessionId, messages.size(), summary.length());
+            log.info("Generated session summary: sessionId={}, round={}, length={}", sessionId, totalTurns, summary.length());
         } catch (Exception e) {
             log.warn("Summary generation failed: {}", e.getMessage());
         }
@@ -259,5 +265,6 @@ public class LongContextManager {
     public void clearSession(String sessionId) {
         redisTemplate.delete(HISTORY_PREFIX + sessionId);
         redisTemplate.delete(SUMMARY_PREFIX + sessionId);
+        redisTemplate.delete(TURN_COUNT_PREFIX + sessionId);
     }
 }

--- a/src/test/java/com/aiagent/infrastructure/memory/LongContextManagerSummaryIntervalTest.java
+++ b/src/test/java/com/aiagent/infrastructure/memory/LongContextManagerSummaryIntervalTest.java
@@ -1,0 +1,106 @@
+package com.aiagent.infrastructure.memory;
+
+import com.aiagent.infrastructure.config.AiProperties;
+import dev.langchain4j.data.embedding.Embedding;
+import dev.langchain4j.model.chat.ChatLanguageModel;
+import dev.langchain4j.model.embedding.EmbeddingModel;
+import dev.langchain4j.model.output.Response;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class LongContextManagerSummaryIntervalTest {
+
+    private static final int TOTAL_TURNS = 30;
+
+    @Mock
+    private RedisTemplate<String, Object> redisTemplate;
+
+    @Mock
+    private ChatLanguageModel chatLanguageModel;
+
+    @Mock
+    private EmbeddingModel embeddingModel;
+
+    @Mock
+    private ValueOperations<String, Object> valueOperations;
+
+    private final Map<String, Object> redisStore = new HashMap<>();
+    private final Map<String, AtomicLong> redisCounters = new HashMap<>();
+
+    private AiProperties aiProperties;
+    private LongContextManager manager;
+
+    @BeforeEach
+    void setUp() {
+        aiProperties = new AiProperties();
+        aiProperties.getSession().setTtl(86400);
+        aiProperties.getSession().setMaxMessages(100);
+        manager = new LongContextManager(chatLanguageModel, embeddingModel, redisTemplate, aiProperties);
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void shouldSummarizeOncePerIntervalAfterSlidingWindowIsFull() {
+        stubRedisAndModels();
+
+        saveTurns("session-1", TOTAL_TURNS);
+
+        int summaryInterval = aiProperties.getSession().getSummaryInterval();
+        verify(chatLanguageModel, times(TOTAL_TURNS / summaryInterval)).generate(anyString());
+        List<Map<String, Object>> summaries = (List<Map<String, Object>>) redisStore.get("ai:summary:session-1");
+        assertThat(summaries).hasSize(TOTAL_TURNS / summaryInterval);
+        assertThat(summaries.get(summaries.size() - 1).get("round")).isEqualTo((long) TOTAL_TURNS);
+    }
+
+    @Test
+    void shouldKeepSummarizingWhenIntervalDoesNotDivideSlidingWindowSize() {
+        aiProperties.getSession().setSummaryInterval(4);
+        stubRedisAndModels();
+
+        saveTurns("session-1", TOTAL_TURNS);
+
+        verify(chatLanguageModel, times(TOTAL_TURNS / 4)).generate(anyString());
+    }
+
+    private void saveTurns(String sessionId, int turns) {
+        for (int index = 0; index < turns; index++) {
+            manager.saveMessageAndMaybeSummarize(sessionId, index % 2 == 0 ? "user" : "assistant", "消息" + index);
+        }
+    }
+
+    private void stubRedisAndModels() {
+        when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+        when(valueOperations.get(anyString()))
+                .thenAnswer(invocation -> redisStore.get(invocation.getArgument(0, String.class)));
+        doAnswer(invocation -> {
+            redisStore.put(invocation.getArgument(0, String.class), invocation.getArgument(1));
+            return null;
+        }).when(valueOperations).set(anyString(), any(), anyLong(), any(TimeUnit.class));
+        when(valueOperations.increment(anyString())).thenAnswer(invocation -> redisCounters
+                .computeIfAbsent(invocation.getArgument(0, String.class), key -> new AtomicLong())
+                .incrementAndGet());
+        when(chatLanguageModel.generate(anyString())).thenReturn("生成的摘要");
+        when(embeddingModel.embed("生成的摘要")).thenReturn(new Response<>(new Embedding(new float[]{1.0f, 0.2f})));
+    }
+}

--- a/src/test/java/com/aiagent/infrastructure/memory/LongContextManagerTest.java
+++ b/src/test/java/com/aiagent/infrastructure/memory/LongContextManagerTest.java
@@ -56,6 +56,7 @@ class LongContextManagerTest {
     void shouldSaveMessageWithoutSummaryWhenBelowThreshold() {
         when(redisTemplate.opsForValue()).thenReturn(valueOperations);
         when(valueOperations.get("ai:history:session-1")).thenReturn(new ArrayList<>());
+        when(valueOperations.increment("ai:turns:session-1")).thenReturn(1L);
 
         manager.saveMessageAndMaybeSummarize("session-1", "user", "你好");
 
@@ -76,6 +77,7 @@ class LongContextManagerTest {
         }
         when(valueOperations.get("ai:history:session-1")).thenReturn(messages);
         when(valueOperations.get("ai:summary:session-1")).thenReturn(null);
+        when(valueOperations.increment("ai:turns:session-1")).thenReturn(10L);
         when(chatLanguageModel.generate(anyString())).thenReturn("生成的摘要");
         when(embeddingModel.embed("生成的摘要")).thenReturn(new Response<>(new Embedding(new float[]{1.0f, 0.2f})));
 
@@ -139,6 +141,7 @@ class LongContextManagerTest {
 
         verify(redisTemplate).delete("ai:history:session-1");
         verify(redisTemplate).delete("ai:summary:session-1");
+        verify(redisTemplate).delete("ai:turns:session-1");
     }
 
     private static Map<String, Object> summary(String text, float[] embedding) {


### PR DESCRIPTION
Fixes #1

## 问题

`LongContextManager.saveMessageAndMaybeSummarize` 先把会话历史截断到 `slidingWindowSize`，再用**截断后**的 `messages.size()` 对 `summaryInterval` 取模来决定是否生成摘要。窗口填满后 `messages.size()` 恒等于 `slidingWindowSize`，`AiProperties` 注释里 "Generate one summary after every N dialogue turns" 的契约退化为常量条件：

- 默认配置（`sliding-window-size: 10` / `summary-interval: 5`）：`10 % 5 == 0` 恒真 → **此后每存一条消息都触发一次摘要 LLM 调用 + 一次 embedding 调用**（`AiAgentService` 每轮对话调用两次，语义缓存命中路径也不例外）；
- 间隔不整除窗口（如 10 / 4）：条件恒假 → **窗口填满后摘要永久停止**，且无任何日志报警；
- `summaryInterval > slidingWindowSize`：从头到尾一次摘要都不会生成。

详细分析见 #1。

## 改动

最小修复，共 3 个文件（主代码净变化 17 行）：

1. **`LongContextManager.java`**：新增独立的累计消息计数 key（`ai:turns:<sessionId>`，Redis `INCR` 原子自增，TTL 与历史记录一致），摘要触发条件改用该累计计数取模——滑动窗口的职责是给历史列表设上界，天生不能兼任单调递增的轮次计数器。配套改动：
   - `clearSession` 一并删除计数 key；
   - 摘要条目的 `round` 字段与日志改用累计计数（原先窗口满后恒为 10，摘要历史失去时序信息）。
2. **`LongContextManagerSummaryIntervalTest.java`**（新增回归测试）：用内存 Map 模拟 Redis 使状态跨调用可见，覆盖"窗口饱和后按间隔摘要"与"间隔不整除窗口时摘要不停止"两个场景。
3. **`LongContextManagerTest.java`**：既有用例补 `increment` stub 与计数 key 的删除断言，断言语义不变。

## 测试证据

**回归测试在修复前失败**（`git stash` 主代码改动后运行 `mvn -Dtest=LongContextManagerSummaryIntervalTest test`）：

```
[ERROR] Tests run: 2, Failures: 2, Errors: 0, Skipped: 0

shouldSummarizeOncePerIntervalAfterSlidingWindowIsFull:
  chatLanguageModel.generate(<any string>);
  Wanted 6 times ... But was 22 times   ← 30 条消息、间隔 5，每条消息都在触发摘要

shouldKeepSummarizingWhenIntervalDoesNotDivideSlidingWindowSize:
  Wanted 7 times ... But was 2 times    ← 间隔 4 时第 8 条之后摘要永久停止
```

**修复后 memory 相关测试全部通过**（`mvn -Dtest='LongContextManager*' test`）：

```
[INFO] Tests run: 8, Failures: 0, Errors: 0, Skipped: 0
[INFO] BUILD SUCCESS
```

**全量 `mvn test`**：

```
[ERROR] Tests run: 247, Failures: 0, Errors: 3, Skipped: 0
```

3 个 Error 为 `AiAgentApplicationTests.contextLoads` 与 `ObservabilityEndpointsTest` 两例，均是 Spring 上下文加载失败（`JwtTokenProvider` bean 构造异常），**在未改动的 `main`（abf9846）上以同样方式失败**（已本地对照验证），与本 PR 无关；其余 244 个用例全部通过。

## 披露

本修复在 AI 辅助下完成，作者已本地复现并审阅每一处改动。
